### PR TITLE
implemented process_pipeline methods

### DIFF
--- a/code/iplc-sim.c
+++ b/code/iplc-sim.c
@@ -320,46 +320,72 @@ void iplc_sim_push_pipeline_stage()
  */
 void iplc_sim_process_pipeline_rtype(char *instruction, int dest_reg, int reg1, int reg2_or_constant)
 {
-    /* This is an example of what you need to do for the rest */
-    iplc_sim_push_pipeline_stage();
-    
-    pipeline[FETCH].itype = RTYPE;
-    pipeline[FETCH].instruction_address = instruction_address;
-    
-    strcpy(pipeline[FETCH].stage.rtype.instruction, instruction);
-    pipeline[FETCH].stage.rtype.reg1 = reg1;
-    pipeline[FETCH].stage.rtype.reg2_or_constant = reg2_or_constant;
-    pipeline[FETCH].stage.rtype.dest_reg = dest_reg;
+	/* This is an example of what you need to do for the rest */
+	iplc_sim_push_pipeline_stage();
+
+	pipeline[FETCH].itype = RTYPE;
+	pipeline[FETCH].instruction_address = instruction_address;
+
+	strcpy(pipeline[FETCH].stage.rtype.instruction, instruction);
+	pipeline[FETCH].stage.rtype.reg1 = reg1;
+	pipeline[FETCH].stage.rtype.reg2_or_constant = reg2_or_constant;
+	pipeline[FETCH].stage.rtype.dest_reg = dest_reg;
 }
 
 void iplc_sim_process_pipeline_lw(int dest_reg, int base_reg, unsigned int data_address)
 {
-    /* You must implement this function */
+	iplc_sim_push_pipeline_stage();
+
+	pipeline[FETCH].itype = LW;
+	pipeline[FETCH].instruction_address = instruction_address;
+	pipeline[FETCH].stage.lw.dest_reg = dest_reg;
+	pipeline[FETCH].stage.lw.base_reg = base_reg;
+	pipeline[FETCH].stage.lw.data_address = data_address;
 }
 
 void iplc_sim_process_pipeline_sw(int src_reg, int base_reg, unsigned int data_address)
 {
-    /* You must implement this function */
+	iplc_sim_push_pipeline_stage();
+
+	pipeline[FETCH].itype = SW;
+	pipeline[FETCH].instruction_address = instruction_address;
+	pipeline[FETCH].stage.sw.src_reg = src_reg;
+	pipeline[FETCH].stage.sw.base_reg = base_reg;
+	pipeline[FETCH].stage.sw.data_address = data_address;
 }
 
 void iplc_sim_process_pipeline_branch(int reg1, int reg2)
 {
-    /* You must implement this function */
+	iplc_sim_push_pipeline_stage();
+
+	pipeline[FETCH].itype = BRANCH;
+	pipeline[FETCH].instruction_address = instruction_address;
+	pipeline[FETCH].stage.branch.reg1 = reg1;
+	pipeline[FETCH].stage.branch.reg2 = reg2;
 }
 
 void iplc_sim_process_pipeline_jump(char *instruction)
 {
-    /* You must implement this function */
+	iplc_sim_push_pipeline_stage();
+
+	pipeline[FETCH].itype = JUMP;
+	pipeline[FETCH].instruction_address = instruction_address;
+
+	strcpy(pipeline[FETCH].stage.jump.instruction, instruction);
 }
 
 void iplc_sim_process_pipeline_syscall()
 {
-    /* You must implement this function */
+	iplc_sim_push_pipeline_stage();
+
+	pipeline[FETCH].itype = SYSCALL;
+	pipeline[FETCH].instruction_address = instruction_address;
 }
 
 void iplc_sim_process_pipeline_nop()
 {
-    /* You must implement this function */
+	iplc_sim_push_pipeline_stage();
+	pipeline[FETCH].itype = NOP;
 }
 
 /************************************************************************************************/


### PR DESCRIPTION
I implemented the iplc_sim_process_pipeline_** methods for all instruction types. 

It seemed to me that the example was pretty much just copying instruction data from the function parameters to the pipeline array, so that's what I did for each one.